### PR TITLE
Minimize crashes (Fix false returns)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ class $modify(ColoredNameLevelInfoLayer, LevelInfoLayer) {
 
 			/*less crashes*/
 			if (!title || !difficulty) {
-				return false;
+				return true;
 			};
 
 			/*now onto editing the level info layer*/
@@ -147,7 +147,7 @@ class $modify(ColoredNameLevelListLayer, LevelListLayer) {
 
 			/*less crashes*/
 			if (!title || !difficulty) {
-				return false;
+				return true;
 			};
 
 			/*now onto editing the list info layer*/
@@ -473,7 +473,7 @@ class $modify(ColoredNameInfoLayer, InfoLayer) {
 
 			/*less crashes*/
 			if (!title) {
-				return false;
+				return true;
 			};
 
 			/*get the difficulty*/
@@ -539,7 +539,7 @@ class $modify(ColoredNameInfoLayer, InfoLayer) {
 
 			/*less crashes*/
 			if (!title) {
-				return false;
+				return true;
 			};
 		
 			/*i'll update this to use the current difficulty whenever i find out how to get it.*/


### PR DESCRIPTION
If false is returned on init, the game will crash.
It's okay to return false when checking the original init, just don't do it anywhere else in the hook.